### PR TITLE
Use the X-Simperium-API-Key header and json data to fix authenticating to the simperium API

### DIFF
--- a/simperium/core.py
+++ b/simperium/core.py
@@ -42,10 +42,11 @@ class Auth(object):
         otherwise.
         """
 
-        data = {"client_id": self.api_key, "username": username, "password": password}
+        data = {"username": username, "password": password}
+        headers = {'X-Simperium-API-Key': self.api_key}
 
         url = self._build_url(self.appname + "/create/")
-        r = requests.post(url, data=data)
+        r = requests.post(url, json=data, headers=headers)
         r.raise_for_status()
         return r.json().get("access_token")
 
@@ -54,9 +55,11 @@ class Auth(object):
         Get the access token for a user.
         Returns the access token as a string or raises an error on failure.
         """
-        data = {"client_id": self.api_key, "username": username, "password": password}
+        data = {"username": username, "password": password}
+        headers = {'X-Simperium-API-Key': self.api_key}
+
         url = self._build_url(self.appname + "/authorize/")
-        r = requests.post(url, data=data)
+        r = requests.post(url, json=data, headers=headers)
         r.raise_for_status()
         return r.json()["access_token"]
 


### PR DESCRIPTION
Originally noticed when using sncli that stopped being able to login this weekend.
I opened https://github.com/insanum/sncli/issues/109

After a bit of digging I found a similar project using the `X-Simperium-API-Key` header instead of a `client_id` in the data body https://github.com/simplenote-vim/simplenote.py/blob/master/simplenote/simplenote.py#L78 

This PR uses a similar approach and I managed to make sncli work with this.
Notice I also had to change the parameter of `post.requests` from `data` to `json` otherwise the API would return `missing username or password`.

Something must have changed on the simperium API and deprecated the old authentication method.